### PR TITLE
add unix domain socket support for redis

### DIFF
--- a/config_example.json
+++ b/config_example.json
@@ -25,6 +25,8 @@
             "purgeInterval": 300
         },
         "redis": {
+            "_disabled_socket": "/var/run/redis/redis.sock",
+            "_socket": "Set socket to enable UNIX domain sockets, otherwise leave unset and set host and port."
             "host": "127.0.0.1",
             "port": 6379,
             "password": ""
@@ -55,6 +57,8 @@
     },
 
     "redis": {
+        "_disabled_socket": "/var/run/redis/redis.sock",
+        "_socket": "Set socket to enable UNIX domain sockets, otherwise leave unset and set host and port."
         "host": "127.0.0.1",
         "port": 6379,
         "password": ""

--- a/init.js
+++ b/init.js
@@ -14,6 +14,7 @@ var PoolWorker = require('./libs/poolWorker.js');
 var PaymentProcessor = require('./libs/paymentProcessor.js');
 var Website = require('./libs/website.js');
 var ProfitSwitch = require('./libs/profitSwitch.js');
+var CreateRedisClient = require('./libs/createRedisClient.js');
 
 var algos = require('stratum-pool/lib/algoProperties.js');
 
@@ -202,7 +203,7 @@ var spawnPoolWorkers = function(){
             delete poolConfigs[coin];
         } else if (!connection) {
             redisConfig = pcfg.redis;
-            connection = redis.createClient(redisConfig.port, redisConfig.host);
+            connection = CreateRedisClient(redisConfig);
             if (redisConfig.password != "") {
                 connection.auth(redisConfig.password);
                 connection.on("error", function (err) {
@@ -210,8 +211,7 @@ var spawnPoolWorkers = function(){
                 });
             }
             connection.on('ready', function(){
-                logger.debug('PPLNT', coin, 'TimeShare processing setup with redis (' + redisConfig.host +
-                    ':' + redisConfig.port  + ')');
+                logger.debug('PPLNT', coin, 'TimeShare processing setup with redis (' + connection.snompEndpoint + ')');
             });
         }
     });

--- a/libs/createRedisClient.js
+++ b/libs/createRedisClient.js
@@ -1,0 +1,13 @@
+var redis = require('redis');
+
+module.exports = function createRedisClient(redisConfig) {
+
+    var bSocket = ((typeof redisConfig.socket !== "undefined") && (redisConfig.socket != ""));
+    var client = bSocket ?
+        redis.createClient(redisConfig.socket) :
+        redis.createClient(redisConfig.port, redisConfig.host);
+
+    client.snompEndpoint = bSocket ? redisConfig.socket : redisConfig.host + ':' + redisConfig.port;
+
+    return client;
+};

--- a/libs/paymentProcessor.js
+++ b/libs/paymentProcessor.js
@@ -6,6 +6,7 @@ var async = require('async');
 
 var Stratum = require('stratum-pool');
 var util = require('stratum-pool/lib/util.js');
+var CreateRedisClient = require('./createRedisClient.js');
 
 module.exports = function(logger){
 
@@ -34,7 +35,11 @@ module.exports = function(logger){
 
             logger.debug(logSystem, logComponent, 'Payment processing setup with daemon ('
                 + processingConfig.daemon.user + '@' + processingConfig.daemon.host + ':' + processingConfig.daemon.port
-                + ') and redis (' + poolOptions.redis.host + ':' + poolOptions.redis.port + ')');                
+                + ') and redis ('
+                + ((typeof poolOptions.redis.socket !== "undefined" && poolOptions.redis.socket !== "")
+                    ? poolOptions.redis.socket
+                    : (poolOptions.redis.host + ':' + poolOptions.redis.port))
+                + ')');
         });
     });
 };
@@ -83,7 +88,7 @@ function SetupForPool(logger, poolOptions, setupFinished){
     var daemon = new Stratum.daemon.interface([processingConfig.daemon], function(severity, message){
         logger[severity](logSystem, logComponent, message);
     });
-    var redisClient = redis.createClient(poolOptions.redis.port, poolOptions.redis.host);
+    var redisClient = CreateRedisClient(poolOptions.redis);
     // redis auth if enabled
     if (poolOptions.redis.password) {
         redisClient.auth(poolOptions.redis.password);

--- a/libs/poolWorker.js
+++ b/libs/poolWorker.js
@@ -4,6 +4,7 @@ var net     = require('net');
 
 var MposCompatibility = require('./mposCompatibility.js');
 var ShareProcessor = require('./shareProcessor.js');
+var CreateRedisClient = require('./createRedisClient.js');
 
 module.exports = function(logger){
 
@@ -18,7 +19,7 @@ module.exports = function(logger){
 
     var proxySwitch = {};
 
-    var redisClient = redis.createClient(portalConfig.redis.port, portalConfig.redis.host);
+    var redisClient = CreateRedisClient(portalConfig.redis);
     if (portalConfig.redis.password) {
         redisClient.auth(portalConfig.redis.password);
     }

--- a/libs/shareProcessor.js
+++ b/libs/shareProcessor.js
@@ -1,5 +1,6 @@
 var redis = require('redis');
 var Stratum = require('stratum-pool');
+var CreateRedisClient = require('./createRedisClient.js');
 
 
 
@@ -26,13 +27,12 @@ module.exports = function(logger, poolConfig){
     var logComponent = coin;
     var logSubCat = 'Thread ' + (parseInt(forkId) + 1);
     
-    var connection = redis.createClient(redisConfig.port, redisConfig.host);
+    var connection = CreateRedisClient(redisConfig);
     if (redisConfig.password) {
         connection.auth(redisConfig.password);
     }
     connection.on('ready', function(){
-        logger.debug(logSystem, logComponent, logSubCat, 'Share processing setup with redis (' + redisConfig.host +
-            ':' + redisConfig.port  + ')');
+        logger.debug(logSystem, logComponent, logSubCat, 'Share processing setup with redis (' + connection.snompEndpoint + ')');
     });
     connection.on('error', function(err){
         logger.error(logSystem, logComponent, logSubCat, 'Redis client had an error: ' + JSON.stringify(err))

--- a/libs/website.js
+++ b/libs/website.js
@@ -16,6 +16,7 @@ var util = require('stratum-pool/lib/util.js');
 
 var api = require('./api.js');
 
+var CreateRedisClient = require('./createRedisClient.js');
 
 module.exports = function(logger){
 
@@ -133,7 +134,7 @@ module.exports = function(logger){
     var buildKeyScriptPage = function(){
         async.waterfall([
             function(callback){
-                var client = redis.createClient(portalConfig.redis.port, portalConfig.redis.host);
+                var client = CreateRedisClient(portalConfig);
                 if (portalConfig.redis.password) {
                     client.auth(portalConfig.redis.password);
                 }


### PR DESCRIPTION
Set `config.redis.socket` to your redis socket (`/var/run/redis/redis.sock`) to enable UNIX domain sockets.

Otherwise, set `config.redis.host` & `config.redis.port` for standard tcp connections.

standard connection:
```json
    "redis": {
        "host": "127.0.0.1",
        "port": 6379,
        "password": ""
    },
```

unix domain socket connection:
```json
    "redis": {
        "socket": "/var/run/redis/redis.sock",
        "password": ""
    },
```

upstream PR https://github.com/s-nomp/s-nomp/pull/141 merged upstream in commit https://github.com/s-nomp/s-nomp/commit/4d32cd8eeb79fdc5d9fe714a2fb008b8484c404b