### PR TITLE
pplnt fix

### DIFF
--- a/coins/vrsc.json
+++ b/coins/vrsc.json
@@ -4,7 +4,7 @@
     "algorithm": "verushash",
     "sapling": 227520,
     "txfee": 0.0005,
-    "requireShielding": true,
+    "requireShielding": false,
     "burnFees": false,
 
     "explorer": {

--- a/libs/paymentProcessor.js
+++ b/libs/paymentProcessor.js
@@ -966,7 +966,7 @@ function SetupForPool(logger, poolOptions, setupFinished){
                                                 if (workerTimes[address] != null && parseFloat(workerTimes[address]) > 0) {
                                                     var timePeriod = roundTo(parseFloat(workerTimes[address] || 1) / maxTime , 2);
                                                     if (timePeriod > 0 && timePeriod < pplntTimeQualify) {
-                                                        var lost = shares - (shares * timePeriod);
+                                                        var lost = shares - (shares * timePeriod / pplntTimeQualify);
                                                         sharesLost += lost;
                                                         shares = Math.max(shares - lost, 0);
                                                     }
@@ -1018,7 +1018,7 @@ function SetupForPool(logger, poolOptions, setupFinished){
                                                 if (workerTimes[address] != null && parseFloat(workerTimes[address]) > 0) {
                                                     var timePeriod = roundTo(parseFloat(workerTimes[address] || 1) / maxTime , 2);
                                                     if (timePeriod > 0 && timePeriod < pplntTimeQualify) {
-                                                        var lost = shares - (shares * timePeriod);
+                                                        var lost = shares - (shares * timePeriod / pplntTimeQualify);
                                                         sharesLost += lost;
                                                         shares = Math.max(shares - lost, 0);
                                                         logger.warning(logSystem, logComponent, 'PPLNT: Reduced shares for '+workerAddress+' round:' + round.height + ' maxTime:'+maxTime+'sec timePeriod:'+roundTo(timePeriod,6)+' shares:'+tshares+' lost:'+lost+' new:'+shares);

--- a/pool_configs/examples/vrsc.json
+++ b/pool_configs/examples/vrsc.json
@@ -34,6 +34,8 @@
         "enabled": true,
         "paymentMode": "prop",
         "_comment_paymentMode":"prop, pplnt",
+		"pplnt": 51,
+        "_comment_pplnt": "If pplnt is active and clients have mined less that this part, their shares are slashed."
         "paymentInterval": 120,
         "_comment_paymentInterval": "Interval in seconds to check and perform payments.",
         "minimumPayment": 1,

--- a/website/pages/miner_stats.html
+++ b/website/pages/miner_stats.html
@@ -40,7 +40,16 @@
     .boxLowerHeader{
         font-size: 1.3em;
         margin: 0 0 5px 10px;
+		width: 175px;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
     }
+	
+	.boxLowerHeader:hover {
+		overflow: visible;
+	}
+
 
     #boxStatsLeft{
         color: black;
@@ -101,5 +110,5 @@
 	var _miner = "{{=String(it.stats.address).split(".")[0]}}";
 	var _workerCount = 0;
 	window.statsSource = new EventSource("/api/live_stats");
-    document.querySelector('main').appendChild(document.createElement('script')).src = '/static/miner_stats.js';
+    document.querySelector('main').appendChild(document.createElement('script')).src = '/static/js/miner_stats.js';
 </script>

--- a/website/pages/miner_stats.html
+++ b/website/pages/miner_stats.html
@@ -110,5 +110,5 @@
 	var _miner = "{{=String(it.stats.address).split(".")[0]}}";
 	var _workerCount = 0;
 	window.statsSource = new EventSource("/api/live_stats");
-    document.querySelector('main').appendChild(document.createElement('script')).src = '/static/js/miner_stats.js';
+    document.querySelector('main').appendChild(document.createElement('script')).src = '/static/miner_stats.js';
 </script>

--- a/website/static/miner_stats.js
+++ b/website/static/miner_stats.js
@@ -173,6 +173,7 @@ function updateWorkerStats() {
 		$("#statsBalance"+htmlSafeWorkerName).text(statData.workers[w].balance);
 		$("#statsShares"+htmlSafeWorkerName).text(Math.round(statData.workers[w].currRoundShares * 100) / 100);
 		$("#statsDiff"+htmlSafeWorkerName).text(statData.workers[w].diff);
+		$("#statsLastShare"+htmlSafeWorkerName).text(Date(statData.workers[w].lastShare));
 	}
 }
 function addWorkerToDisplay(name, htmlSafeName, workerObj) {
@@ -190,6 +191,7 @@ function addWorkerToDisplay(name, htmlSafeName, workerObj) {
 	htmlToAdd+='<div><i class="fa fa-gavel"></i> <small>Luck <span id="statsLuckDays'+htmlSafeName+'">'+workerObj.luckDays+'</span> Days</small></div>';
 	htmlToAdd+='<div><i class="fa fa-money"></i> <small>Bal: <span id="statsBalance'+htmlSafeName+'">'+workerObj.balance+'</span></small></div>';
 	htmlToAdd+='<div><i class="fa fa-money"></i> <small>Paid: <span id="statsPaid'+htmlSafeName+'">'+workerObj.paid+'</span></small></div>';
+	htmlToAdd+='<div><i class="fa fa-signal"></i> <small>Last share: <span id="statsLastShare'+htmlSafeName+'">'+(Math.floor(((new Date().getTime()) - (new Date(Math.round(workerObj.lastShare)).getTime())) / 1000))+'s ago</span></small></div>';
 	htmlToAdd+='</div></div></div>';
 	$("#boxesWorkers").html($("#boxesWorkers").html()+htmlToAdd);
 }

--- a/website/static/miner_stats.js
+++ b/website/static/miner_stats.js
@@ -173,7 +173,7 @@ function updateWorkerStats() {
 		$("#statsBalance"+htmlSafeWorkerName).text(statData.workers[w].balance);
 		$("#statsShares"+htmlSafeWorkerName).text(Math.round(statData.workers[w].currRoundShares * 100) / 100);
 		$("#statsDiff"+htmlSafeWorkerName).text(statData.workers[w].diff);
-		$("#statsLastShare"+htmlSafeWorkerName).text(Date(statData.workers[w].lastShare));
+		$("#statsLastShare"+htmlSafeWorkerName).text(Math.floor(((new Date().getTime()) - (new Date(Math.round(statData.workers[w].lastShare)).getTime())) / 1000));
 	}
 }
 function addWorkerToDisplay(name, htmlSafeName, workerObj) {


### PR DESCRIPTION
- Added `"pplnt": 0.50,` to `coins/examples/vrsc.json`
- Added `" _pplnt_comment" to `coins/examples/vrsc.json`

- added division by `pplntTimeQualify` to the lost share calculation. Instead of a steep drop-off at the pplnt value and then going linearly to 0, shares are now reduced linear from 100% shares to 0 at the cut-off point.