### PR TITLE
Add merged mining compatibility

### DIFF
--- a/coins/verustest.json
+++ b/coins/verustest.json
@@ -5,7 +5,7 @@
     "sapling": 120,
     "txfee": 0.0005,
     "requireShielding": true,
-    "burnFees": true,
+    "burnFees": false,
 
     "explorer": {
         "txURL": "https://explorer.veruscoin.io/tx/",

--- a/coins/verustest.json
+++ b/coins/verustest.json
@@ -6,6 +6,7 @@
     "txfee": 0.0005,
     "requireShielding": true,
     "burnFees": true,
+    "pbaasActivationHeight": 1,
 
     "explorer": {
         "txURL": "https://explorer.veruscoin.io/tx/",

--- a/coins/verustest.json
+++ b/coins/verustest.json
@@ -6,7 +6,6 @@
     "txfee": 0.0005,
     "requireShielding": true,
     "burnFees": true,
-    "pbaasActivationHeight": 1,
 
     "explorer": {
         "txURL": "https://explorer.veruscoin.io/tx/",

--- a/coins/vrsc.json
+++ b/coins/vrsc.json
@@ -6,6 +6,7 @@
     "txfee": 0.0005,
     "requireShielding": true,
     "burnFees": false,
+    "pbaasActivationHeight": 2546600,
 
     "explorer": {
         "txURL": "https://explorer.veruscoin.io/tx/",

--- a/coins/vrsc.json
+++ b/coins/vrsc.json
@@ -6,7 +6,6 @@
     "txfee": 0.0005,
     "requireShielding": true,
     "burnFees": false,
-    "pbaasActivationHeight": 2546600,
 
     "explorer": {
         "txURL": "https://explorer.veruscoin.io/tx/",

--- a/libs/poolWorker.js
+++ b/libs/poolWorker.js
@@ -182,8 +182,11 @@ module.exports = function(logger){
                 logger.debug(logSystem, logComponent, logSubCat, 'We thought a block was found but it was rejected by the daemon, share data: ' + shareData);
 
             else if (isValidBlock)
-                logger.debug(logSystem, logComponent, logSubCat, 'Block found: ' + data.blockHash + ' by ' + data.worker);
-
+                if (!data.blockOnlyPBaaS) {
+                    logger.debug(logSystem, logComponent, logSubCat, 'Block found: ' + data.blockHash + ' [' + data.height + '] by ' + data.worker);
+                } else {
+                    logger.debug(logSystem, logComponent, logSubCat, 'PBaaS found: ' + data.blockHash + ' by ' + data.worker);
+                }
             if (isValidShare) {
                 if(data.shareDiff > 1000000000) {
                     logger.debug(logSystem, logComponent, logSubCat, 'Share was found with diff higher than 1.000.000.000!');

--- a/libs/shareProcessor.js
+++ b/libs/shareProcessor.js
@@ -72,11 +72,7 @@ module.exports = function(logger, poolConfig){
 
         if (isValidShare) {
             redisCommands.push(['hincrbyfloat', coin + ':shares:roundCurrent', shareData.worker, shareData.difficulty]);
-            redisCommands.push(['hincrby', coin + ':stats', 'validShares', 1]);            
-            if (shareData.pbass_subscribe === true) {
-                redisCommands.push(['hincrbyfloat', coin + ':shares:pbaasCurrent', shareData.worker, shareData.difficulty]);
-            }
-
+            redisCommands.push(['hincrby', coin + ':stats', 'validShares', 1]);
         } else {
             redisCommands.push(['hincrby', coin + ':stats', 'invalidShares', 1]);
         }
@@ -89,10 +85,9 @@ module.exports = function(logger, poolConfig){
         redisCommands.push(['zadd', coin + ':hashrate', dateNow / 1000 | 0, hashrateData.join(':')]);
 
         if (isValidBlock){
-            if (shareData.pbass_subscribe === true) {
-                redisCommands.push(['sadd', coin + ':pbaasPending', [shareData.blockHash, shareData.worker, dateNow].join(':')]);
-            }
-
+            // track potential pbaas blocks ( need lookup and processing )
+            redisCommands.push(['sadd', coin + ':pbaasPending', [shareData.blockHash, shareData.worker, dateNow].join(':')]);
+            // track main chain blocks
             if (!shareData.blockOnlyPBaaS) {        
                 redisCommands.push(['rename', coin + ':shares:roundCurrent', coin + ':shares:round' + shareData.height]);
                 redisCommands.push(['rename', coin + ':shares:timesCurrent', coin + ':shares:times' + shareData.height]);

--- a/libs/shareProcessor.js
+++ b/libs/shareProcessor.js
@@ -85,10 +85,17 @@ module.exports = function(logger, poolConfig){
         redisCommands.push(['zadd', coin + ':hashrate', dateNow / 1000 | 0, hashrateData.join(':')]);
 
         if (isValidBlock){
-            redisCommands.push(['rename', coin + ':shares:roundCurrent', coin + ':shares:round' + shareData.height]);
-            redisCommands.push(['rename', coin + ':shares:timesCurrent', coin + ':shares:times' + shareData.height]);
-            redisCommands.push(['sadd', coin + ':blocksPending', [shareData.blockHash, shareData.txHash, shareData.height, shareData.worker, dateNow].join(':')]);
-            redisCommands.push(['hincrby', coin + ':stats', 'validBlocks', 1]);
+            if (!shareData.blockOnlyPBaaS) {        
+                redisCommands.push(['rename', coin + ':shares:roundCurrent', coin + ':shares:round' + shareData.height]);
+                redisCommands.push(['rename', coin + ':shares:timesCurrent', coin + ':shares:times' + shareData.height]);
+                redisCommands.push(['sadd', coin + ':blocksPending', [shareData.blockHash, shareData.txHash, shareData.height, shareData.worker, dateNow].join(':')]);
+                redisCommands.push(['hincrby', coin + ':stats', 'validBlocks', 1]);
+            } else {
+                // TODO, copy pbaas shares for current round ...    
+                //redisCommands.push(['rename', coin + ':shares:roundCurrent', coin + ':shares:round' + shareData.height]);
+                //redisCommands.push(['rename', coin + ':shares:timesCurrent', coin + ':shares:times' + shareData.height]);
+                redisCommands.push(['sadd', coin + ':pbaasPending', [shareData.blockHash, shareData.worker, dateNow].join(':')]);
+            }
         }
         else if (shareData.blockHash){
             redisCommands.push(['hincrby', coin + ':stats', 'invalidBlocks', 1]);

--- a/libs/shareProcessor.js
+++ b/libs/shareProcessor.js
@@ -71,6 +71,7 @@ module.exports = function(logger, poolConfig){
         var redisCommands = [];
 
         if (isValidShare) {
+            redisCommands.push(['hincrbyfloat', coin + ':shares:pbaasCurrent', shareData.worker, shareData.difficulty]);
             redisCommands.push(['hincrbyfloat', coin + ':shares:roundCurrent', shareData.worker, shareData.difficulty]);
             redisCommands.push(['hincrby', coin + ':stats', 'validShares', 1]);
         } else {


### PR DESCRIPTION
:warning: NEAR COMPLETE :warning:
----
Support new fee pool and merged mining for pbaas activation

Depends on:
https://github.com/VerusCoin/node-stratum-pool/pull/12
https://github.com/VerusCoin/verushash-node/pull/10  

   IMPORTANT: To support the new fee pool s-nomp can no longer generate the coinbase transaction itself. It is now taken from the daemon. You must setup the daemon with your mining address or block rewards may go to an unexpected address.
   
   HIGHLY RECOMMEND TESTING ON TESTNET FIRST !!!

 - Must be running verusd v1.0.3+
 - Requires daemon to be setup with `--miningdistribution='{"ADDRESS"} -gen -genproclimit=0`
 - Requires `-miningdistributionpassthrough -gen -genproclimit=1` to be setup on pbaas chain daemons
 - Test merged mining with  latest hminer: <https://github.com/hellcatz/hminer/releases>
 - Other miners may support merged mining soon™
 
This is currently working on the testnet

**NOTE:** Payment processing support does not exist to send merged mining rewards.
 
In redis you can find new entries that can help:

     verus:pbaasPending            (block hashes to check for rewards on pbaas chains)

To make payments happen, here is an idea ...
   - Take a snapshot of the shares in `verus:shares:pbaasCurrent` (then clear based on your reward scheme)
   - Look up block hashes in `verus:pbassPending` on each pbaas chain to get block details
   - Save the block height, coinbase txid and coinbase reward, then fill `coin:blocksPending` in redis for the pbaas chain. Make sure to follow same format s-nomp uses.
   - Copy the share snapshot to `coin:shares:roundBLOCKHEIGHT` for the pbaas chain with proper block height for pbaas chain
   - Setup a second install of s-nomp with only the pbaas coins enabled to get payments