### PR TITLE
update cliListener.js

### DIFF
--- a/libs/cliListener.js
+++ b/libs/cliListener.js
@@ -9,6 +9,14 @@ var listener = module.exports = function listener(server, port){
         _this.emit('log', text);
     };
 
+    function isJson(str) {
+        try {
+            JSON.parse(str);
+        } catch (e) {
+            return false;
+        }
+        return true;
+    }
 
     this.start = function(){
         net.createServer(function(c) {
@@ -16,12 +24,17 @@ var listener = module.exports = function listener(server, port){
             var data = '';
             try {
                 c.on('data', function (d) {
-                    data += d;
-                    if (data.slice(-1) === '\n') {
-                        var message = JSON.parse(data);
-                        _this.emit('command', message.command, message.params, message.options, function(message){
-                            c.end(message);
-                        });
+                    if (isJson(d.toString())) {
+                        data += d;
+                        if (data.slice(-1) === '\n') {
+                            var message = JSON.parse(data);
+                            _this.emit('command', message.command, message.params, message.options, function(message){
+                                c.end(message);
+                            });
+                        }
+                    } else {
+                        c.end('You must send JSON, not: '+d.toString());
+                        return;
                     }
                 });
                 c.on('end', function () {


### PR DESCRIPTION
Despite being inside a try/catch, data needs pre-validation of JSON.

If one were to send `curl --http0.9 http://127.0.0.1:17117`, the pool can crash with `SyntaxError: Unexpected token 'G', "GET / HTTP"... is not valid JSON` since curl includes headers.
Even sending `curl --http0.9 http://127.0.0.1:17117 -d '{"test": "test"}'` can cause the thread to never send back a reply (causing curl to lock up).

This isn't a patch to allow curl sends to be parsed; but, rather, a fix to protect the pool in any case where the server IP might be known and the port might be accessible or where the op may choose other CLI options.